### PR TITLE
276 render support

### DIFF
--- a/src/v005010/_276_claim_status.rs
+++ b/src/v005010/_276_claim_status.rs
@@ -1,0 +1,74 @@
+pub use super::segment::*;
+use crate::util::Parser;
+use nom::{
+    combinator::{opt, peek},
+    multi::many0,
+    IResult, Parser as _,
+};
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+use x12_types_macros::DisplayX12;
+
+/// 276 - Health Claim Status Request
+#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, DisplayX12)]
+pub struct _276 {
+    pub st: ST,
+    pub bht: BHT,
+    /// Payer Information
+    pub loop_2100a: _276Loop2100A,
+    /// Receiver Information
+    pub loop_2100b: _276Loop2100B,
+    /// Service Provider Detail
+    pub loop_2100c: _276Loop2100C,
+    /// Subscriber Information
+    pub loop_2000d: _276Loop2000D,
+    /// Payer Claim Control Number - Loop 2200D
+    pub loop_2200d: _276Loop2200D,
+
+    pub se: SE,
+}
+
+/// Payer Information
+#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, DisplayX12)]
+pub struct _276Loop2100A {
+    pub hl: HL,
+    pub nm1: NM1,
+}
+
+/// Receiver Information
+#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, DisplayX12)]
+pub struct _276Loop2100B {
+    pub hl: HL,
+    pub nm1: NM1,
+}
+
+/// Service Provider Information
+#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, DisplayX12)]
+pub struct _276Loop2100C {
+    pub hl: HL,
+    pub nm1: NM1,
+}
+
+/// Subscriber Information
+#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, DisplayX12)]
+pub struct _276Loop2000D {
+    pub hl: HL,
+    /// Date of Birth
+    pub nm1: NM1,
+    pub dmg: Option<DMG>,
+    /// Subscriber Name - loop 2100D
+    pub trn: TRN,
+}
+
+/// Claim Search Information
+#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, DisplayX12)]
+pub struct _276Loop2200D {
+    /// Payer Claim Control number
+    pub r#ref: Vec<REF>,
+    /// Total claim charge amount
+    pub amt: Option<AMT>,
+    /// Claim Service Date
+    pub dtp: DTP,
+    /// Service line Information - Loop 2210D
+    pub svc: Vec<SVC>,
+}

--- a/src/v005010/_276_claim_status.rs
+++ b/src/v005010/_276_claim_status.rs
@@ -1,12 +1,5 @@
 pub use super::segment::*;
-use crate::util::Parser;
-use nom::{
-    combinator::{opt, peek},
-    multi::many0,
-    IResult, Parser as _,
-};
 use serde::{Deserialize, Serialize};
-use std::fmt::Display;
 use x12_types_macros::DisplayX12;
 
 /// 276 - Health Claim Status Request

--- a/src/v005010/_276_claim_status.rs
+++ b/src/v005010/_276_claim_status.rs
@@ -21,6 +21,36 @@ pub struct _276 {
     pub se: SE,
 }
 
+// Helper functions to manage the SE segment count. The caller is going to
+// have a hard time calculating this, so the library should help out.
+// It'd be good if all of the doc types had something like this, and better
+// if it could be maintained automatically.
+impl _276 {
+    // Need a better way to do this. This is a hokey implementation for now.
+    // It'd be better if we could calculate this without doing so much work.
+    pub fn get_segment_count(&self) -> usize {
+        let str_276 = self.to_string();
+        let segments: Vec<&str> = dbg!(str_276
+            .split("~")
+            .filter(|seg| seg.trim().len() > 0)
+            .collect());
+        segments.len()
+    }
+
+    /// Set the SE01 segment count. Normally pass None for count
+    /// to allow counting automatically and setting to calculated count.
+    /// If the count is failing for some reason, you can pass one in.
+    pub fn set_se_segment_count(&mut self, count: Option<usize>) {
+        let count = if let Some(cnt) = count {
+            cnt
+        } else {
+            self.get_segment_count()
+        };
+
+        self.se._01 = count.to_string()
+    }
+}
+
 /// Payer Information
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, DisplayX12)]
 pub struct _276Loop2100A {

--- a/src/v005010/mod.rs
+++ b/src/v005010/mod.rs
@@ -11,6 +11,9 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use x12_types_macros::DisplayX12;
 
+mod _276_claim_status;
+pub use _276_claim_status::*;
+
 mod segment;
 
 #[cfg(test)]


### PR DESCRIPTION
Added support for creating EDI 276 documents. It'd be great if this could be pulled into the main library. 

This produces 276 documents that validate with the remote as of now. Will probably need to make minor changes to it as we go through testing, so leaving this as a draft for the moment. While I've got the hood open, any feedback would be great.

I've also included a couple helper functions that are pretty rudimentary, but which can help manage the SE segment count of the 276. It'd be great if we could generalize that a bit and include it for all doc types. I can remove it and put it in my own code if necessary, but I do feel like the library should help out a little here. 